### PR TITLE
Feature/step17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.redisson:redisson-spring-boot-starter:3.33.0'
+    //kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 tasks.named('test') {

--- a/docker-kafka-compose.yml
+++ b/docker-kafka-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.1
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:7.4.1
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1

--- a/src/main/java/com/hhplusconcert/common/util/JsonUtil.java
+++ b/src/main/java/com/hhplusconcert/common/util/JsonUtil.java
@@ -1,0 +1,40 @@
+package com.hhplusconcert.common.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.*;
+public class JsonUtil {
+    private JsonUtil() {
+    }
+
+    public static String toJson(Object target) {
+        String result = "";
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(MapperFeature.PROPAGATE_TRANSIENT_MARKER, true);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+
+        try {
+            ObjectWriter writer = mapper.writer().withoutAttribute("logger").withoutAttribute("typeName");
+            return writer.writeValueAsString(target);
+        } catch (JsonProcessingException var4) {
+            var4.printStackTrace();
+            return result;
+        }
+    }
+
+    public static <T> T fromJson(String json, Class<T> clazz) {
+        T result = null;
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(MapperFeature.PROPAGATE_TRANSIENT_MARKER, true);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+
+        try {
+            result = mapper.readValue(json, clazz);
+        } catch (JsonProcessingException var5) {
+            var5.printStackTrace();
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/hhplusconcert/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/com/hhplusconcert/config/kafka/KafkaConsumerConfig.java
@@ -1,0 +1,52 @@
+package com.hhplusconcert.config.kafka;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@Slf4j
+public class KafkaConsumerConfig {
+    //
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        //Message Deserializer 부분
+        return new DefaultKafkaConsumerFactory<>(consumerFactoryConfig());
+    }
+
+    private Map<String, Object> consumerFactoryConfig() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class.getName());
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class.getName());
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, String.class.getName());
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        return props;
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/src/main/java/com/hhplusconcert/config/kafka/KafkaProducerCluster.java
+++ b/src/main/java/com/hhplusconcert/config/kafka/KafkaProducerCluster.java
@@ -1,0 +1,30 @@
+package com.hhplusconcert.config.kafka;
+
+import com.hhplusconcert.common.util.JsonUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaProducerCluster {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public void sendMessage(String topic, Object message) {
+        String payload = JsonUtil.toJson(message);
+        CompletableFuture<SendResult<String, String>> future = kafkaTemplate.send(topic, payload);
+        future.whenComplete((r, e) -> {
+            if (e == null) {
+                log.info("Producer: success >> message: {}, offset: {}", r.getProducerRecord().value(), r.getRecordMetadata().offset());
+            } else {
+                log.error("producer: failure >> message: {}", e.getMessage());
+            }
+        });
+    }
+}

--- a/src/main/java/com/hhplusconcert/config/kafka/KafkaProducerConfig.java
+++ b/src/main/java/com/hhplusconcert/config/kafka/KafkaProducerConfig.java
@@ -1,0 +1,35 @@
+package com.hhplusconcert.config.kafka;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+    @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        //
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/com/hhplusconcert/domain/point/event/ChargedPoint.java
+++ b/src/main/java/com/hhplusconcert/domain/point/event/ChargedPoint.java
@@ -5,7 +5,7 @@ public record ChargedPoint(
         int amount
 ) {
 
-    public static ChargedPoint on (String requestUserId, int amount) {
+    public static ChargedPoint of(String requestUserId, int amount) {
         return new ChargedPoint(requestUserId, amount);
     }
 }

--- a/src/main/java/com/hhplusconcert/domain/point/event/UsedPoint.java
+++ b/src/main/java/com/hhplusconcert/domain/point/event/UsedPoint.java
@@ -6,7 +6,7 @@ public record UsedPoint(
         int amount
 ) {
 
-    public static UsedPoint on (String requestUserId, String paymentId, int amount) {
+    public static UsedPoint of(String requestUserId, String paymentId, int amount) {
         return new UsedPoint(requestUserId, paymentId, amount);
     }
 }

--- a/src/main/java/com/hhplusconcert/domain/point/stream/PointHistoryConsumer.java
+++ b/src/main/java/com/hhplusconcert/domain/point/stream/PointHistoryConsumer.java
@@ -1,0 +1,42 @@
+package com.hhplusconcert.domain.point.stream;
+
+import com.hhplusconcert.common.util.JsonUtil;
+import com.hhplusconcert.domain.point.event.ChargedPoint;
+import com.hhplusconcert.domain.point.event.UsedPoint;
+import com.hhplusconcert.domain.point.model.vo.PointHistoryStatus;
+import com.hhplusconcert.domain.point.service.PointHistoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PointHistoryConsumer {
+    //
+    private final PointHistoryService pointHistoryService;
+
+    @KafkaListener(topics = {"charged-point"}, groupId = "${concert.topic_groups.point}")
+    public void ChargedPointConsume(String message) {
+        ChargedPoint event = JsonUtil.fromJson(message, ChargedPoint.class);
+        log.info("id {}, amount {}", event.requestUserId(), event.amount());
+
+        String requestUserId = event.requestUserId();
+        int amount = event.amount();
+        this.pointHistoryService.createPointHistory(requestUserId, amount, PointHistoryStatus.CHARGE);
+    }
+
+    @KafkaListener(topics = {"used-point"}, groupId = "point")
+    public void UsedPointConsume(String message) {
+        UsedPoint event = JsonUtil.fromJson(message, UsedPoint.class);
+        log.info("id {}, amount {}", event.requestUserId(), event.amount());
+
+        String requestUserId = event.requestUserId();
+        String paymentId = event.paymentId();
+        int amount = event.amount();
+        this.pointHistoryService.createPointHistory(requestUserId, amount, PointHistoryStatus.USE, paymentId);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,10 +25,21 @@ spring:
       port: 6379
   cache:
     type: redis
+  kafka:
+    bootstrap-servers: localhost:9092
+    template:
+      default-topic: dev-topic
+    producer:
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      group-id: dev-group
+      value-deserializer: org.apache.kafka.common.serialization.ByteArrayDeserializer
 concert:
   limit:
     processCount: 50
   queueKey: 'concert-waiting-queue'
+  topic_groups:
+    point: point
 
 
 server:
@@ -56,10 +67,19 @@ spring:
     redis:
       host: localhost
       port: 6379
+  kafka:
+    producer:
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      group-id: test-group
+      value-deserializer: org.apache.kafka.common.serialization.ByteArrayDeserializer
+      auto-offset-reset: earliest
 concert:
   limit:
     processCount: 50
   queueKey: 'concert-waiting-queue-test'
+  topic_groups:
+    point: test-point
 
 
 server:

--- a/src/test/java/com/hhplusconcert/domain/point/stream/PointHistoryConsumerTest.java
+++ b/src/test/java/com/hhplusconcert/domain/point/stream/PointHistoryConsumerTest.java
@@ -1,0 +1,71 @@
+package com.hhplusconcert.domain.point.stream;
+
+import com.hhplusconcert.common.TruncateTableComponent;
+import com.hhplusconcert.config.kafka.KafkaProducerCluster;
+import com.hhplusconcert.domain.point.event.ChargedPoint;
+import com.hhplusconcert.domain.point.event.UsedPoint;
+import com.hhplusconcert.domain.point.model.PointHistory;
+import com.hhplusconcert.domain.point.model.vo.PointHistoryStatus;
+import com.hhplusconcert.domain.point.service.PointHistoryService;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@EmbeddedKafka(partitions = 3, brokerProperties = { "listeners=PLAINTEXT://localhost:9093", "port=9093" })
+class PointHistoryConsumerTest {
+    @Autowired
+    private PointHistoryService pointHistoryService;
+    @Autowired
+    private KafkaProducerCluster producerCluster;
+    @Autowired
+    private TruncateTableComponent truncateTableComponent;
+
+    private final String userId = "test_userId";
+
+    @BeforeEach
+    public void setUp() {
+        truncateTableComponent.truncateTable(() -> {}, "point_history");
+    }
+
+    @Test
+    @DisplayName("Point Charge 후 후처리가 정상적으로 이뤄지는지 검증")
+    void chargedPointConsume() throws InterruptedException {
+        ChargedPoint data = ChargedPoint.of(userId, 10000);
+
+        producerCluster.sendMessage("charged-point", data);
+        Thread.sleep(500);
+        List<PointHistory> histories = this.pointHistoryService.loadPointHistories(userId);
+        assertEquals(1, histories.size());
+        assertEquals(data.requestUserId(), histories.get(0).getUserId());
+        assertEquals(PointHistoryStatus.CHARGE, histories.get(0).getStatus());
+        assertEquals(data.amount(), histories.get(0).getAmount());
+    }
+
+    @Test
+    @DisplayName("Point Use 후 후처리가 정상적으로 이뤄지는지 검증")
+    void usedPointConsume() throws InterruptedException {
+        String paymentId = "test_paymentId";
+        UsedPoint data = UsedPoint.of(userId, paymentId,  10000);
+
+        producerCluster.sendMessage("used-point", data);
+        Thread.sleep(500);
+        List<PointHistory> histories = this.pointHistoryService.loadPointHistories(userId);
+        assertEquals(1, histories.size());
+        assertEquals(data.requestUserId(), histories.get(0).getUserId());
+        assertEquals(data.paymentId(), histories.get(0).getPaymentId());
+        assertEquals(PointHistoryStatus.USE, histories.get(0).getStatus());
+        assertEquals(data.amount(), histories.get(0).getAmount());
+    }
+}


### PR DESCRIPTION
STEP 17
- docker 를 이용해 kafka 를 설치 및 실행하고 애플리케이션과 연결
- 각 프레임워크 (nest.js, spring) 에 적합하게 카프카 consumer, producer 를 연동 및 테스트

point의 charge, use Action시  history생성 부분을 kafka를 사용하도록 리펙토링 진행하였습니다.
docker-compose로 kafka와 zookeeper를 설치 및 실행하도록 하였습니다.

### 리뷰포인트
- 저는 stream을 Event관련하여 작업하는 부분으로 생각하고 구현하였는데 이와 같이 구현해도 괜찮은지 피드백 받고싶습니다.

Interface에 Consumer를 두고, Infra에 Publisher를 두는 것도 생각을 해보았지만, Event를 관리하는 것은 좀더 Domain에 가깝다 생각하여 Domain에 Stream디렉토리를 생성하여 관리하도록 하였습니다. 그리고 해당 도메인에 관련된 이벤트들은 한곳에 모여있는 편이 관리하기 편하다 생각했습니다.

- topic명을 하드코딩으로 관리하는 것을 최대한 피하기 위해 Event객체의 className으로 지정하였는데, 이부분에 대해서도 피드백을 받아보고싶습니다.